### PR TITLE
Revert "limiting user to bash or python or shell"

### DIFF
--- a/script/script-v0.0.1.schema.json
+++ b/script/script-v0.0.1.schema.json
@@ -39,7 +39,6 @@
     "shell": {
       "type": "string",
       "default": "bash",
-      "enum": ["bash", "sh", "/bin/bash", "/bin/sh"],
       "description": "The shell interpreter to use."
     },
     "pre_run": {


### PR DESCRIPTION
This will remove the limitation on the executable, which should be done to match https://github.com/HPC-buildtest/buildtest-framework/pull/233.

Reverts HPC-buildtest/schemas#18