### PR TITLE
adding buildtest settings schema 

### DIFF
--- a/.github/tests/test_organization.py
+++ b/.github/tests/test_organization.py
@@ -52,7 +52,7 @@ def test_schema_naming(tmp_path):
     outer_schema = load_schema(outer_file)
 
     for schema_name in os.listdir(root):
-        print(schema_name)
+
         if (
             schema_name in skips
             or re.search("^([.]|_)", schema_name)

--- a/.github/tests/test_organization.py
+++ b/.github/tests/test_organization.py
@@ -43,7 +43,7 @@ def test_schema_naming(tmp_path):
        - examples folder has subfolders that correspond to existing versions
        - each example has a version that corresponds with it's folder
     """
-    skips = ["README.md", "global", "LICENSE", "examples"]
+    skips = ["README.md", "global", "LICENSE", "examples", "settings"]
     print("Root of testing is %s" % root)
 
     # Read in the outer validator (looks for list with keys and version)
@@ -52,7 +52,7 @@ def test_schema_naming(tmp_path):
     outer_schema = load_schema(outer_file)
 
     for schema_name in os.listdir(root):
-
+        print(schema_name)
         if (
             schema_name in skips
             or re.search("^([.]|_)", schema_name)

--- a/.github/tests/test_settings.py
+++ b/.github/tests/test_settings.py
@@ -1,0 +1,178 @@
+import json
+import os
+import pytest
+import yaml
+from jsonschema import validate
+from jsonschema.exceptions import ValidationError
+
+here = os.path.dirname(os.path.abspath(__file__))
+root = os.path.dirname(os.path.dirname(here))
+
+
+def load_schema(path):
+    """load a schema from file. We assume a json file
+    """
+    with open(path, "r") as fd:
+        schema = json.loads(fd.read())
+    return schema
+
+
+def load_recipe(path):
+    """load a yaml recipe file
+    """
+    with open(path, "r") as fd:
+        content = yaml.load(fd.read(), Loader=yaml.SafeLoader)
+    return content
+
+
+def check_fields(recipe):
+    # check json fields standard to most jsonschemas
+    fields = [
+        "$id",
+        "$schema",
+        "title",
+        "type",
+        "definitions",
+        "properties",
+        "additionalProperties",
+        "required",
+    ]
+    for field in fields:
+        assert field in recipe
+
+    assert (
+        recipe["$id"]
+        == "https://HPC-buildtest.github.io/schemas/settings/settings.schema.json"
+    )
+    assert recipe["$schema"] == "http://json-schema.org/draft-07/schema#"
+    assert recipe["type"] == "object"
+    assert recipe["required"] == ["editor", "executors"]
+    assert recipe["additionalProperties"] == False
+
+
+def check_properties(properties):
+    # -------------------- check 'editor' key ------------------------------
+    assert "editor" in properties
+    assert "type" in properties["editor"]
+    assert properties["editor"]["type"] == "string"
+    assert "enum" in properties["editor"]
+    assert properties["editor"]["enum"] == ["vi", "vim", "nano", "emacs"]
+
+    # -------------------- check 'executors' key ------------------------------
+    assert "executors" in properties
+    assert "type" in properties["executors"]
+    assert "patternProperties" in properties["executors"]
+    assert "anyOf" in properties["executors"]["patternProperties"]["^.*$"]
+
+    # check additionalProperties in properties
+    assert "additionalProperties" in properties
+    assert properties["additionalProperties"] == False
+
+
+def check_definitions(definitions):
+
+    # ------------------ check 'local' object ----------------------
+    assert "local" in definitions
+    assert "type" in definitions["local"]
+    assert definitions["local"]["type"] == "object"
+    assert "properties" in definitions["local"]
+    assert "required" in definitions["local"]
+    assert definitions["local"]["required"] == ["type"]
+
+    local_properties = definitions["local"]["properties"]
+    # ------------ check 'description' -----------------------
+    assert "description" in local_properties
+    assert "type" in local_properties["description"]
+    assert local_properties["description"]["type"] == "string"
+
+    # ------------ check 'type' -----------------------
+    assert "type" in local_properties
+    assert "type" in local_properties["type"]
+    assert local_properties["type"]["type"] == "string"
+
+    assert "enum" in local_properties["type"]
+    assert local_properties["type"]["enum"] == ["local"]
+
+    # ------------ check 'options' -----------------------
+    assert "options" in local_properties
+    assert "type" in local_properties["options"]
+    assert local_properties["options"]["type"] == "array"
+    assert "items" in local_properties["options"]
+    assert "type" in local_properties["options"]["items"]
+    assert local_properties["options"]["items"]["type"] == "string"
+
+    # ------------------ check 'slurm' object ----------------------
+
+    assert "slurm" in definitions
+    assert "type" in definitions["slurm"]
+    assert definitions["slurm"]["type"] == "object"
+    assert "properties" in definitions["slurm"]
+    assert "required" in definitions["slurm"]
+    assert definitions["slurm"]["required"] == ["type", "launcher"]
+    # ------------------ check 'slurm' properties ----------------------
+    slurm_properties = definitions["slurm"]["properties"]
+    # ------------------ check 'description' in slurm properties ----------------------
+    assert "description" in slurm_properties
+    assert "type" in slurm_properties["description"]
+    assert slurm_properties["description"]["type"] == "string"
+    # ------------------ check 'type' in slurm properties ----------------------
+    assert "type" in slurm_properties
+    assert "type" in slurm_properties["type"]
+    assert slurm_properties["type"]["type"] == "string"
+    assert "enum" in slurm_properties["type"]
+    assert slurm_properties["type"]["enum"] == ["slurm"]
+
+    # ------------------ check 'launcher' in slurm properties ----------------------
+    assert "launcher" in slurm_properties
+    assert "type" in slurm_properties["launcher"]
+    assert slurm_properties["launcher"]["type"] == "string"
+    assert "enum" in slurm_properties["launcher"]
+    assert slurm_properties["launcher"]["enum"] == ["sbatch"]
+
+    # ------------------ check 'options' in slurm properties ----------------------
+
+    assert "options" in slurm_properties
+    assert "type" in slurm_properties["options"]
+    assert slurm_properties["options"]["type"] == "array"
+    assert "items" in slurm_properties["options"]
+    assert "type" in slurm_properties["options"]["items"]
+    assert slurm_properties["options"]["items"]["type"] == "string"
+
+
+def test_settings():
+
+    settings_schema = os.path.join(root, "settings", "settings.schema.json")
+    # check if file exists
+    assert settings_schema
+
+    # load schema and ensure type is a dict
+    recipe = load_schema(settings_schema)
+    assert isinstance(recipe, dict)
+
+    check_fields(recipe)
+    check_properties(recipe["properties"])
+    check_definitions(recipe["definitions"])
+
+    valid_recipes = os.path.join(root, "settings", "valid")
+    invalid_recipes = os.path.join(root, "settings", "invalid")
+
+    # check all valid recipes
+    for example in os.listdir(valid_recipes):
+        filepath = os.path.join(valid_recipes, example)
+        print(f"Loading Recipe File: {filepath}")
+        example_recipe = load_recipe(filepath)
+        assert example_recipe
+
+        print(f"Expecting Recipe File: {filepath} to be valid")
+        validate(instance=example_recipe, schema=recipe)
+
+    # check all valid recipes
+    for example in os.listdir(invalid_recipes):
+        filepath = os.path.join(invalid_recipes, example)
+        print(f"Loading Recipe File: {filepath}")
+        example_recipe = load_recipe(filepath)
+        assert example_recipe
+
+        print(f"Expecting Recipe File: {filepath} to be invalid")
+        with pytest.raises(ValidationError) as excinfo:
+            validate(instance=example_recipe, schema=recipe)

--- a/settings/invalid/invalid_executor_type.yml
+++ b/settings/invalid/invalid_executor_type.yml
@@ -1,0 +1,5 @@
+editor: vi
+executors:
+  default:
+    type: localhost
+    description: submit jobs on local machine

--- a/settings/invalid/wrong_editor_value.yml
+++ b/settings/invalid/wrong_editor_value.yml
@@ -1,0 +1,5 @@
+editor: badoption
+executors:
+  default:
+    type: local
+    description: submit jobs on local machine

--- a/settings/settings.schema.json
+++ b/settings/settings.schema.json
@@ -1,0 +1,65 @@
+{
+  "$id": "https://HPC-buildtest.github.io/schemas/settings/settings.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Buildtest Settings Schema",
+  "type": "object",
+  "required": ["editor", "executors"],
+  "additionalProperties": false,
+  "properties": {
+      "editor": { 
+          "type": "string",
+          "enum": ["vi", "vim", "nano", "emacs"]
+      },
+      "executors": {
+          "type": "object",
+          "patternProperties": {
+              "^.*$": {
+                 "anyOf": [
+                     {"$ref": "#/definitions/local"},
+                     {"$ref": "#/definitions/slurm"}
+                 ]
+             }
+          }
+      },
+      "additionalProperties": false       
+  },
+  "definitions": {
+      "local": {
+          "type": "object",          
+          "properties": {
+              "description": {"type": "string"},
+              "type": {
+                  "type": "string",
+                  "enum": ["local"]
+               },
+               "options": {
+                   "type": "array",
+                   "items": {
+                       "type": "string"
+                   }
+               }
+           },
+          "required": ["type"]
+       },
+
+      "slurm": {
+          "type": "object",          
+          "properties": {
+              "description": {"type": "string"},
+              "type": {
+                  "type": "string",
+                  "enum": ["slurm"]
+               },
+              "launcher": {
+                  "type": "string",
+                  "enum": ["sbatch"]
+               },
+               "options": {
+                   "type": "array",
+                   "items": {"type": "string"}
+               }
+           },
+          "required": ["type","launcher"]
+       }
+    }
+}

--- a/settings/valid/local_executor.yml
+++ b/settings/valid/local_executor.yml
@@ -1,0 +1,5 @@
+editor: vi
+executors:
+  default:
+    type: local
+    description: submit jobs on local machine

--- a/settings/valid/local_slurm_combined_executor.yml
+++ b/settings/valid/local_slurm_combined_executor.yml
@@ -1,0 +1,12 @@
+editor: vi
+executors:
+  default:
+    type: local
+    description: submit jobs on local machine
+  slurm-executor:
+    type: slurm
+    description: submit jobs on local machine
+    launcher: sbatch
+    options:
+      - "-p admin"
+      - "-t 01:00"

--- a/settings/valid/slurm_executor.yml
+++ b/settings/valid/slurm_executor.yml
@@ -1,0 +1,9 @@
+editor: vi
+executors:
+  slurm-executor:
+    type: slurm
+    description: submit jobs on local machine
+    launcher: sbatch
+    options:
+      - "-p admin"
+      - "-t 01:00"


### PR DESCRIPTION
@vsoch i found this exercise quite fun but daunting as well, going through and checking each yaml object is going to be very tedious. I did my best and did all the checks, good luck in review :)

This PR is adding the following
- List of valid and invalid examples.
- add schema validation for settings schema in test_settings.py

For now i only added a few examples for valid and invalid case. Right now we can't add all the valid examples in one file, but we may be able to do it if we separate each YAML file into separate documents. For now i named file based on the intended check. I can't see myself testing every single invalid edge case, there are way toooo many cases to check.

I found that having the schema on one separate page for reference will help when reviewing ``test_settings.py`` as there are too many cases to check. I wish there was a way to have coverage for the schema object if it's possible. 